### PR TITLE
Adding correct Diff and GitSigns Highlight groups

### DIFF
--- a/lua/nightgem/init.lua
+++ b/lua/nightgem/init.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 function M.setup()
-
 	vim.cmd("highlight clear")
 	-- vim.cmd("syntax reset")
 	vim.o.background = "dark"
@@ -18,8 +17,16 @@ function M.setup()
 		blue = "#7781ee",
 		light_grey = "#7a7a7a",
 		dark_grey = "#3a3a3a",
-		green = "#65BA7E"
+		green = "#65BA7E",
+
+		bg_diff_add = "#0c210c",
+		bg_diff_change = "#211d0c",
+		bg_diff_remove = "#210c0c",
 	}
+
+	local diffAdd = { fg = colors.green, bg = colors.bg_diff_add }
+	local diffChange = { fg = colors.pink, bg = colors.bg_diff_change }
+	local diffDelete = { fg = colors.red, bg = colors.bg_diff_remove }
 
 	-- Define highlight groups
 
@@ -44,9 +51,7 @@ function M.setup()
 	set(0, "Comment", { fg = colors.dark_grey })
 	set(0, "Delimiter", { fg = colors.green })
 	set(0, "Keyword", { fg = colors.yellow })
-	set(0, "Identifier", { fg = colors.yellow })
 	set(0, "@string", { fg = colors.pink })
-	set(0, "String", { fg = colors.pink })
 	set(0, "@punctiation", { link = "Delimiter" })
 	set(0, "@punctuation.bracket", { fg = colors.light_grey }) -- make parentheses and braces red
 	set(0, "ModeMsg", { fg = colors.light_grey })
@@ -57,7 +62,29 @@ function M.setup()
 	set(0, "MsgArea", { fg = colors.fg })
 	set(0, "Constant", { fg = colors.fg })
 
+	set(0, "DiffAdd", diffAdd)
+	set(0, "DiffChange", diffChange)
+	set(0, "DiffDelete", diffDelete)
 
+	set(0, "GitSignsAdd", diffAdd)
+	set(0, "GitSignsChange", diffChange)
+	set(0, "GitSignsDelete", diffDelete)
+
+	set(0, "GitSignsAddNr", diffAdd)
+	set(0, "GitSignsChangeNr", diffChange)
+	set(0, "GitSignsDeleteNr", diffDelete)
+
+	set(0, "GitSignsAddLn", { bg = colors.bg_diff_add })
+	set(0, "GitSignsChangeLn", { bg = colors.bg_diff_change })
+	set(0, "GitSignsDeleteLn", { bg = colors.bg_diff_remove })
+
+	set(0, "GitSignsAddInline", diffAdd)
+	set(0, "GitSignsChangeInline", diffChange)
+	set(0, "GitSignsDeleteInline", diffDelete)
+
+	set(0, "GitSignsAddLnInline", diffAdd)
+	set(0, "GitSignsChangeLnInline", diffChange)
+	set(0, "GitSignsDeleteLnInline", diffDelete)
 end
 
 return M


### PR DESCRIPTION
I found out that there are no proper styles configured for GitSigns highlight groups.

I added them in, also i tried to stay minimal but was forced to add 3 more colors for the background of the Diff highlight groups.

I think it looks way better than unstyled.

<details>
<summary>Preview/Screenshots</summary>

## Old GitSigns highlights
<img width="635" height="121" alt="image" src="https://github.com/user-attachments/assets/a48ca9be-b3dc-4112-aee7-d5709e138de3" />

## Old GitSigns (LineHL)
<img width="748" height="114" alt="image" src="https://github.com/user-attachments/assets/356892c1-63ad-4362-85c8-7beff4409bba" />

---

## New GitSigns highlights
<img width="651" height="166" alt="image" src="https://github.com/user-attachments/assets/076a3c29-7ad1-466c-bb2c-0d21af9c1017" />

## New GitSigns (LineHL)
<img width="599" height="132" alt="image" src="https://github.com/user-attachments/assets/8bc27037-3dac-4f5d-a123-081cd0df0dba" />


</details>